### PR TITLE
feat(csharp/client): DH-20522: Add SAML support to CorePlus client

### DIFF
--- a/csharp/client/Dhe_NetClient/auth/Credentials.cs
+++ b/csharp/client/Dhe_NetClient/auth/Credentials.cs
@@ -1,11 +1,36 @@
 ﻿//
 // Copyright (c) 2016-2025 Deephaven Data Labs and Patent Pending
 //
+using System.Security.Cryptography;
+
 namespace Deephaven.Dhe_NetClient;
 
 public abstract class Credentials {
+  /// <summary>
+  /// Generates a PasswordCredentials with the specified fields.
+  /// </summary>
+  /// <returns><see cref="Credentials"/> for use with username/password</returns>
   public static Credentials OfUsernamePassword(string user, string password, string operateAs) {
     return new PasswordCredentials(user, password, operateAs);
+  }
+
+  /// <summary>
+  /// Generates a SamlCredentials with a new, crytprographically-random nonce.
+  /// </summary>
+  /// <returns><see cref="Credentials"/> for use with SAML</returns>
+  public static Credentials OfSaml(string nonce) {
+    return new SamlCredentials(nonce);
+  }
+
+  /// <summary>
+  /// Generates a new, crytprographically-random nonce for use with OfSaml
+  /// </summary>
+  /// <returns>The nonce</returns>
+  public static string GenerateRandomNonceForSaml() {
+    var bytes = new byte[96];
+    RandomNumberGenerator.Fill(bytes);
+    var nonce = Convert.ToBase64String(bytes);
+    return nonce;
   }
 
   internal class PasswordCredentials(string user, string password,
@@ -14,5 +39,8 @@ public abstract class Credentials {
     public readonly string Password = password;
     public readonly string OperateAs = operateAs;
   }
-}
 
+  internal class SamlCredentials(string nonce) : Credentials {
+    public readonly string Nonce = nonce;
+  }
+}

--- a/csharp/client/Dhe_NetClient/session/ConfigurationInfo.cs
+++ b/csharp/client/Dhe_NetClient/session/ConfigurationInfo.cs
@@ -1,0 +1,59 @@
+﻿using Grpc.Core;
+using System.Diagnostics.CodeAnalysis;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using System.Web;
+
+namespace Deephaven.Dhe_NetClient;
+
+public sealed class ConfigurationInfo {
+  [JsonPropertyName("auth_host")]
+  public required string[] AuthHost { get; init; }
+  [JsonPropertyName("auth_port")]
+  public required UInt16 AuthPort { get; init; }
+  [JsonPropertyName("controller_host")]
+  public required string ControllerHost { get; init; }
+  [JsonPropertyName("controller_port")]
+  public required UInt16 ControllerPort { get; init; }
+  [JsonPropertyName("truststore_url")]
+  public string? TruststoreUrl { get; init; }
+  [JsonPropertyName("override_authorities")]
+  public bool OverrideAuthorities { get; init; }
+  [JsonPropertyName("auth_authority")]
+  public string? AuthAuthority { get; init; }
+  [JsonPropertyName("controller_authority")]
+  public string? ControllerAuthority { get; init; }
+  [JsonPropertyName("saml_sso_uri")]
+  public string? SamlSsoUri { get; init; }
+
+  public static ConfigurationInfo OfJson(string input) {
+    var result = JsonSerializer.Deserialize<ConfigurationInfo>(input);
+    return result ?? throw new Exception("JsonSerializer returned null");
+  }
+
+  public static ConfigurationInfo OfUrl(string url, bool validateCertificate) {
+    var handler = new HttpClientHandler();
+    if (!validateCertificate) {
+      handler.ClientCertificateOptions = ClientCertificateOption.Manual;
+      handler.ServerCertificateCustomValidationCallback = (_, _, _, _) => true;
+    }
+    using var hc = new HttpClient(handler);
+    var json = hc.GetStringAsync(url).Result;
+
+    return OfJson(json);
+  }
+
+  public bool TryMakeSamlAuthUrl(string nonce, out string url) {
+    if (SamlSsoUri == null) {
+      url = "";
+      return false;
+    }
+
+    var uriBuilder = new UriBuilder(SamlSsoUri);
+    var query = HttpUtility.ParseQueryString(uriBuilder.Query);
+    query["key"] = nonce;
+    uriBuilder.Query = query.ToString();
+    url = uriBuilder.ToString();
+    return true;
+  }
+}


### PR DESCRIPTION
These are changes to the C# Core+ client needed to support SAML authentication. One customer of this is the Excel Add-In.

Basically the changes are
1. A new subclass of `Credentials` called `SamlCredentials`, containing the `nonce` used to authenticate to Deephaven
2. Code to generate that nonce
3. Code that switches on the authentication type, and calls the API entry point `AuthenticateByExternal`

Also we redo the code that does the `configuration.json` parsing (the JSON file that you get when you connect to a JSON server at e.g. `https://myserver.org:8123/iris/connection.json`. We move that to a separate `ConfigurationInfo` class. It also has a new method, `TryMakeSamlAuthUrl`; which is the URL you would paste into a browser (or auto-launch a browser with) to do the user's steps for authentication.

For background, this is how we do SAML authentication.
1. Generate a nonce, a large, cryptographically-random string
2. Point the user's browser to the Deephaven SAML URL (obtained from the configuration.json) with 'key=`nonce`' as part of the URL query. Here the user will authenticate using (typically using Google SSO credentials, but could in principle be something else).
3. Meanwhile our code makes a gRPC call `authenticateByExternal` with the same nonce. This will succeed if the user completed step 2.