### PR TITLE
feat(csharp/client): DH-20522: Fix connectivity bug

### DIFF
--- a/csharp/client/Dhe_NetClient/controller/SubscriptionContext.cs
+++ b/csharp/client/Dhe_NetClient/controller/SubscriptionContext.cs
@@ -105,7 +105,6 @@ internal class SubscriptionContext : IDisposable {
           }
 
           var serial = qi.Config.Serial;
-          Console.WriteLine($"Serial is {serial:x}");
           _synced.PqMap = _synced.PqMap.With(serial, qi);
           return;
         }

--- a/csharp/client/Dhe_NetClient/session/SessionManager.cs
+++ b/csharp/client/Dhe_NetClient/session/SessionManager.cs
@@ -206,14 +206,13 @@ public class SessionManager : IDisposable {
       throw new Exception($"{pqStrForErr} has invalid url='{url}'", e);
     }
 
-    var urlScheme = uri.Scheme;
-    var urlTarget = uri.Host + uri.PathAndQuery;
+    var connectionString = $"{uri.Host}:{uri.Port}";
     var envoyPrefix = infoMsg.State.ConnectionDetails.EnvoyPrefix;
     var scriptLanguage = infoMsg.Config.ScriptLanguage;
-    var useTls = urlScheme == Uri.UriSchemeHttps;
+    var useTls = uri.Scheme == Uri.UriSchemeHttps;
     return ConnectToDndWorker(
       pqSerial,
-      urlTarget,
+      connectionString,
       useTls,
       envoyPrefix,
       scriptLanguage);


### PR DESCRIPTION
We were picking out the wrong pieces of the URL in order to form a connection string of the form `host:port`. In a future PR we will do this in a more error-proof fashion.

Also, while we're here, delete a stray `Console.WriteLine`