### PR TITLE
feat: DH-21800: Build Enterprise C# client for both net8.0 and net10.0

### DIFF
--- a/csharp/client/Dhe_NetClient/Dhe_NetClient.csproj
+++ b/csharp/client/Dhe_NetClient/Dhe_NetClient.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net10.0</TargetFramework>
+    <TargetFrameworks>net8.0;net10.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <RootNamespace>Deephaven.Dhe_NetClient</RootNamespace>
@@ -34,7 +34,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Deephaven.Core.Client" Version="0.41.2.1" />
+    <PackageReference Include="Deephaven.Core.Client" Version="0.41.2.2" />
     <PackageReference Include="Google.Protobuf" Version="3.31.1" />
     <PackageReference Include="Grpc.Net.Client" Version="2.71.0" />
     <PackageReference Include="Grpc.Tools" Version="2.72.0">
@@ -44,10 +44,11 @@
   </ItemGroup>
 
   <ItemGroup>
-    <None Update="README-nuget.md">
-      <Pack>True</Pack>
-      <PackagePath>\</PackagePath>
-    </None>
+    <None Include="$(MSBuildProjectDirectory)\README-nuget.md"
+        Pack="true"
+        PackagePath="\"
+        Link="README-nuget.md"
+        Visible="false" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
The reason the README-nuget.md clause had to change is because .NET gets confused trying to find that file in the multitarget scenario.

Also the project now references the new multitarget Deephaven-core project (https://github.com/deephaven/deephaven-core/pull/7722)